### PR TITLE
Set Content-Type header to avoid "415 Unsupported Media Type" error

### DIFF
--- a/src/AppCore.php
+++ b/src/AppCore.php
@@ -63,7 +63,7 @@ class AppCore
         }
         
         $is_raw = $params['format'] == 'raw';
-        $result = $client->execute($params['method'], $args, $reqattrs = [], $requestId = null, $headers = [], $is_raw, $params['resultonly']);
+        $result = $client->execute($params['method'], $args, $reqattrs = [], $requestId = null, $headers = ['Content-Type' => 'application/json'], $is_raw, $params['resultonly']);
         
         $map = [HttpClient::level_info => MyLogger::info,
                 HttpClient::level_debug => MyLogger::debug,


### PR DESCRIPTION
Hi @dan-da, thanks for the useful tool! 😃 

I'm facing the `415 Unsupported Media Type` below:

```sh
$ ./jsonrpc-cli --format=raw --httpfile=/tmp/http.log --resultonly=off http://127.0.0.1:8545/ shh_info

$ tail -f /tmp/http.log
POST / HTTP/1.0
Accept: text/xml,application/xml,application/xhtml+xml,text/html,text/plain,image/png,image/jpeg,image/gif,*/*
Accept-Language: en-us
Host: 127.0.0.1
User-Agent: Mozilla/4.0 (compatible; jsonrpc-cli HTTP Client; Darwin)
Connection: Close
Content-Length: 52
Cookie:

{"jsonrpc":"2.0","method":"shh_info","id":836307265}

HTTP/1.0 415 Unsupported Media Type
content-type: text/plain; charset=utf-8
content-length: 81
date: Tue, 21 Jan 2020 13:19:56 GMT
```

I think setting Content-Type header could be solution for the error. Please review this PR when you have time.